### PR TITLE
Upgrade nginx-ingress-controller to 0.20.0

### DIFF
--- a/katalog/nginx/deployment.yml
+++ b/katalog/nginx/deployment.yml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
@@ -98,4 +98,3 @@ spec:
   - name: metrics
     port: 10254
     targetPort: metrics
-    

--- a/katalog/nginx/kustomization.yaml
+++ b/katalog/nginx/kustomization.yaml
@@ -7,7 +7,3 @@ resources:
   - deployment.yml
   - sm.yml
   - rules.yml
-
-imageTags:
-  - name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    newTag: "0.19.0"


### PR DESCRIPTION
In order to leverage regex-based path matching we need to update nginx-ingress-controller to (at least) version 0.20.0.